### PR TITLE
Add Vue resume builder with Express AI backend

### DIFF
--- a/resume-builder/.env.example
+++ b/resume-builder/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to server/.env and set your OpenAI API key
+OPENAI_API_KEY=

--- a/resume-builder/README.md
+++ b/resume-builder/README.md
@@ -1,0 +1,53 @@
+# Resume Builder
+
+A minimalist resume builder with a Vue 3 + Vite frontend and a lightweight Express API that leverages OpenAI for content improvements.
+
+## Features
+- Real-time two-column resume preview with Simple and Modern templates.
+- Repeatable experience and education entries, skill tag rendering, and optional target job description.
+- AI-assisted improvements for summary, experience bullet points, and skill suggestions.
+- Local JSON save/load plus download/upload support.
+- Light/Dark theme toggle with persistence and print-friendly layout for PDF export.
+
+## Setup
+
+```bash
+# root
+cd resume-builder
+npm install
+npm run dev  # runs Vite and the Express server together
+
+# server (for environment configuration or standalone use)
+cd server
+cp ../.env.example .env
+# edit .env to add OPENAI_API_KEY
+npm install
+npm run dev
+```
+
+## Environment Variables
+Create a `.env` file inside `server/` with:
+
+```
+OPENAI_API_KEY=your_key_here
+```
+
+The server will return a helpful error if the key is missing.
+
+## Scripts
+- `npm run dev`: Starts Vite and the Express API concurrently.
+- `npm run build`: Builds the Vue application for production.
+- `npm run preview`: Previews the production build locally.
+- `npm run lint`: Type-checks the project with `vue-tsc`.
+
+Within `server/`:
+- `npm run dev`: Starts the API with hot reload (`ts-node-dev`).
+- `npm run build`: Builds the server to JavaScript.
+- `npm start`: Runs the built server.
+
+## Printing to PDF
+Use the **Print / Export PDF** button to open the browser print dialog. Choose “Save as PDF” for an A4-friendly export. Controls are hidden and layout is optimized during printing.
+
+## Rate Limiting
+The `/api/generate` endpoint uses a simple in-memory limiter allowing up to 30 requests per hour per IP.
+

--- a/resume-builder/env.d.ts
+++ b/resume-builder/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/resume-builder/index.html
+++ b/resume-builder/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Resume Builder</title>
+  </head>
+  <body class="antialiased">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/resume-builder/package.json
+++ b/resume-builder/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "resume-builder",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently \"vite\" \"npm run dev --prefix server\"",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "vue-tsc --noEmit"
+  },
+  "dependencies": {
+    "vue": "^3.4.21"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "autoprefixer": "^10.4.17",
+    "concurrently": "^8.2.2",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.8",
+    "vue-tsc": "^2.0.6"
+  }
+}

--- a/resume-builder/postcss.config.js
+++ b/resume-builder/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/resume-builder/server/index.ts
+++ b/resume-builder/server/index.ts
@@ -1,0 +1,90 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import { requestImprovements, ResumePayload } from './openai.js';
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+
+app.use(
+  cors({
+    origin: ['http://localhost:5173'],
+    methods: ['POST', 'OPTIONS'],
+    allowedHeaders: ['Content-Type']
+  })
+);
+app.use(express.json({ limit: '1mb' }));
+
+type RateBucket = { count: number; reset: number };
+const RATE_LIMIT = 30;
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+const rateMap = new Map<string, RateBucket>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const existing = rateMap.get(ip);
+  if (!existing || now > existing.reset) {
+    rateMap.set(ip, { count: 1, reset: now + RATE_WINDOW_MS });
+    return false;
+  }
+  existing.count += 1;
+  if (existing.count > RATE_LIMIT) {
+    return true;
+  }
+  return false;
+}
+
+app.post('/api/generate', async (req, res) => {
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(500).json({ error: 'Missing OpenAI API key. Set OPENAI_API_KEY in server/.env.' });
+  }
+
+  const ip = req.ip || req.headers['x-forwarded-for']?.toString() || 'global';
+  if (isRateLimited(ip)) {
+    return res.status(429).json({ error: 'Rate limit exceeded. Please try again later.' });
+  }
+
+  const payload = req.body as ResumePayload;
+
+  try {
+    const raw = await requestImprovements(payload);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      console.error('Failed to parse OpenAI response', raw);
+      return res.status(502).json({ error: 'Failed to parse AI response. Please retry.' });
+    }
+
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed) ||
+      typeof (parsed as any).summary !== 'string' ||
+      !Array.isArray((parsed as any).experience) ||
+      !Array.isArray((parsed as any).skills)
+    ) {
+      return res.status(502).json({ error: 'AI response missing required fields.' });
+    }
+
+    const expValid = (parsed as any).experience.every((item: any) => Array.isArray(item?.descriptionBullets));
+    if (!expValid) {
+      return res.status(502).json({ error: 'AI experience data malformed.' });
+    }
+
+    return res.json(parsed);
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: 'Failed to improve resume. Please try again.' });
+  }
+});
+
+app.get('/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.listen(PORT, () => {
+  console.log(`Resume Builder API running on http://localhost:${PORT}`);
+});

--- a/resume-builder/server/openai.ts
+++ b/resume-builder/server/openai.ts
@@ -1,0 +1,59 @@
+import OpenAI from 'openai';
+
+type ExperienceInput = {
+  company: string;
+  role: string;
+  start: string;
+  end: string;
+  description: string;
+};
+
+type EducationInput = {
+  school: string;
+  degree: string;
+  years: string;
+};
+
+export interface ResumePayload {
+  personal: Record<string, string>;
+  summary: string;
+  experience: ExperienceInput[];
+  education: EducationInput[];
+  skills: string[];
+  jobDescription?: string;
+}
+
+let client: OpenAI | null = null;
+
+function getClient(): OpenAI {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('Missing OPENAI_API_KEY');
+  }
+  if (!client) {
+    client = new OpenAI({ apiKey });
+  }
+  return client;
+}
+
+export async function requestImprovements(payload: ResumePayload): Promise<string> {
+  const openai = getClient();
+  const model = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+  const system = `You are an expert resume editor. Improve clarity, concision, and impact without inventing facts. Maintain a professional tone, third-person omitted perspective, and consistent verb tense.`;
+  const user = `Here is the resume data as JSON:\n${JSON.stringify(payload, null, 2)}\n\nInstructions:\n- Rewrite the summary into 3-4 sentences that highlight achievements succinctly.\n- For each experience item, produce 3-5 bullet points focusing on quantifiable impact and action verbs.\n- Suggest 10-15 relevant skills based on the resume and optional job description.\n- Keep information truthful to the input.\n- Respond with strict minified JSON matching this schema:\n{\n  "summary": "string",\n  "experience": [{"descriptionBullets": ["..."]}],\n  "skills": ["Skill A"]\n}`;
+
+  const response = await openai.chat.completions.create({
+    model,
+    temperature: 0.4,
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: user }
+    ]
+  });
+
+  const choice = response.choices[0]?.message?.content;
+  if (!choice) {
+    throw new Error('No response from OpenAI');
+  }
+  return choice.trim();
+}

--- a/resume-builder/server/package.json
+++ b/resume-builder/server/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "resume-builder-server",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "openai": "^4.41.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.30",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/resume-builder/server/tsconfig.json
+++ b/resume-builder/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/resume-builder/src/App.vue
+++ b/resume-builder/src/App.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="flex min-h-screen flex-col bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    <TopBar />
+    <main class="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-6 py-6 lg:flex-row">
+      <section class="lg:w-2/5">
+        <div class="sticky top-6 flex flex-col gap-4 lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto">
+          <div class="space-y-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-950">
+            <div class="flex flex-wrap gap-2">
+              <button
+                type="button"
+                class="inline-flex items-center justify-center rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-400"
+                @click="handleImprove"
+                :disabled="aiLoading"
+              >
+                <span v-if="aiLoading" class="flex items-center gap-2">
+                  <span class="h-2 w-2 animate-ping rounded-full bg-white"></span>
+                  Thinking...
+                </span>
+                <span v-else>Improve With AI</span>
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center justify-center rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:border-blue-500 hover:text-blue-600 dark:border-gray-700 dark:text-gray-200 dark:hover:border-blue-400"
+                @click="handlePrint"
+              >
+                Print / Export PDF
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center justify-center rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:border-blue-500 hover:text-blue-600 dark:border-gray-700 dark:text-gray-200 dark:hover:border-blue-400"
+                @click="handleSave"
+              >
+                Save
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center justify-center rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:border-blue-500 hover:text-blue-600 dark:border-gray-700 dark:text-gray-200 dark:hover:border-blue-400"
+                @click="handleLoad"
+              >
+                Load
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center justify-center rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:border-blue-500 hover:text-blue-600 dark:border-gray-700 dark:text-gray-200 dark:hover:border-blue-400"
+                @click="handleDownload"
+              >
+                Download JSON
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center justify-center rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:border-blue-500 hover:text-blue-600 dark:border-gray-700 dark:text-gray-200 dark:hover:border-blue-400"
+                @click="triggerUpload"
+              >
+                Upload JSON
+              </button>
+              <input ref="uploadInput" type="file" accept="application/json" class="hidden" @change="onUpload" />
+            </div>
+            <p v-if="aiError" class="text-sm text-red-600">{{ aiError }}</p>
+            <p v-if="statusMessage" class="text-sm text-emerald-600">{{ statusMessage }}</p>
+            <p class="text-xs text-gray-500">Data is stored locally in your browser when you save.</p>
+          </div>
+          <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-950">
+            <FormPanel
+              :form="form"
+              @update-personal="updatePersonal"
+              @update-summary="(value) => (form.summary = value)"
+              @update-experience="updateExperience"
+              @update-education="updateEducation"
+              @update-skills="(value) => (form.skills = value)"
+              @update-job-description="(value) => (form.jobDescription = value)"
+            />
+          </div>
+        </div>
+      </section>
+      <section class="flex-1 lg:w-3/5">
+        <div class="flex flex-col gap-4">
+          <div class="flex items-center justify-between">
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">Preview</h2>
+            <div class="flex gap-2 text-sm">
+              <button
+                v-for="option in templateOptions"
+                :key="option.value"
+                type="button"
+                @click="form.template = option.value"
+                class="rounded-md border px-3 py-1.5 font-medium transition"
+                :class="[
+                  form.template === option.value
+                    ? 'border-blue-500 bg-blue-50 text-blue-600 dark:border-blue-400 dark:bg-blue-400/10 dark:text-blue-200'
+                    : 'border-gray-300 text-gray-600 hover:border-blue-500 hover:text-blue-600 dark:border-gray-700 dark:text-gray-300'
+                ]"
+              >
+                {{ option.label }}
+              </button>
+            </div>
+          </div>
+          <PreviewPanel :form="form" :skills="skillsList" :template="form.template" />
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue';
+import TopBar from './components/TopBar.vue';
+import FormPanel from './components/FormPanel.vue';
+import PreviewPanel from './components/PreviewPanel.vue';
+import {
+  createEducationItem,
+  createExperienceItem,
+  createResumeForm,
+  parseSkills,
+  splitBullets,
+  type ExperienceItem,
+  type EducationItem,
+  type PersonalInfo,
+  type ResumeForm
+} from './lib/schema';
+import { downloadResume, loadResume, readResumeFile, saveResume } from './lib/storage';
+import { improveResume } from './lib/ai';
+
+const form = reactive<ResumeForm>(createResumeForm());
+const aiLoading = ref(false);
+const aiError = ref('');
+const statusMessage = ref('');
+const uploadInput = ref<HTMLInputElement | null>(null);
+
+const templateOptions = [
+  { value: 'simple' as const, label: 'Simple' },
+  { value: 'modern' as const, label: 'Modern' }
+];
+
+const skillsList = computed(() => parseSkills(form.skills));
+
+function updatePersonal({ field, value }: { field: keyof PersonalInfo; value: string }) {
+  form.personal[field] = value;
+}
+
+function normalizeExperience(list: ExperienceItem[]): ExperienceItem[] {
+  const items = list.length ? list : [createExperienceItem()];
+  return items.map((item) => ({
+    id: item.id || createExperienceItem().id,
+    company: item.company || '',
+    role: item.role || '',
+    start: item.start || '',
+    end: item.end || '',
+    description: item.description || '',
+    descriptionBullets: Array.isArray(item.descriptionBullets)
+      ? item.descriptionBullets
+      : splitBullets(item.description || '')
+  }));
+}
+
+function normalizeEducation(list: EducationItem[]): EducationItem[] {
+  const items = list.length ? list : [createEducationItem()];
+  return items.map((item) => ({
+    id: item.id || createEducationItem().id,
+    school: item.school || '',
+    degree: item.degree || '',
+    years: item.years || ''
+  }));
+}
+
+function updateExperience(items: ExperienceItem[]) {
+  form.experience = normalizeExperience(items);
+}
+
+function updateEducation(items: EducationItem[]) {
+  form.education = normalizeEducation(items);
+}
+
+function plainForm(): ResumeForm {
+  return JSON.parse(JSON.stringify(form)) as ResumeForm;
+}
+
+async function handleImprove() {
+  aiError.value = '';
+  statusMessage.value = '';
+  aiLoading.value = true;
+  try {
+    const response = await improveResume(form);
+    if (response.summary) {
+      form.summary = response.summary;
+    }
+    if (Array.isArray(response.experience)) {
+      response.experience.forEach((item, index) => {
+        const target = form.experience[index];
+        if (!target) return;
+        const bullets = item.descriptionBullets?.filter((bullet) => bullet.trim().length > 0) ?? [];
+        target.descriptionBullets = bullets;
+        target.description = bullets.join('\n');
+      });
+    }
+    if (Array.isArray(response.skills) && response.skills.length) {
+      form.skills = response.skills.join(', ');
+    }
+    statusMessage.value = 'AI suggestions applied.';
+  } catch (error) {
+    aiError.value = error instanceof Error ? error.message : 'Failed to contact AI service.';
+  } finally {
+    aiLoading.value = false;
+  }
+}
+
+function handlePrint() {
+  window.print();
+}
+
+function handleSave() {
+  saveResume(plainForm());
+  statusMessage.value = 'Resume saved to this browser.';
+}
+
+function handleLoad() {
+  const stored = loadResume();
+  if (!stored) {
+    statusMessage.value = 'No saved resume found.';
+    return;
+  }
+  applyForm(stored);
+  statusMessage.value = 'Resume loaded from storage.';
+}
+
+function handleDownload() {
+  downloadResume(plainForm());
+}
+
+function triggerUpload() {
+  uploadInput.value?.click();
+}
+
+async function onUpload(event: Event) {
+  const target = event.target as HTMLInputElement;
+  const file = target.files?.[0];
+  if (!file) return;
+  try {
+    const data = await readResumeFile(file);
+    applyForm(data);
+    statusMessage.value = 'Resume uploaded.';
+  } catch (error) {
+    aiError.value = error instanceof Error ? error.message : 'Failed to read resume file.';
+  } finally {
+    target.value = '';
+  }
+}
+
+function applyForm(data: ResumeForm) {
+  Object.assign(form.personal, data.personal || {});
+  form.summary = data.summary || '';
+  form.skills = data.skills || '';
+  form.jobDescription = data.jobDescription || '';
+  form.template = data.template || form.template;
+  form.experience = normalizeExperience(Array.isArray(data.experience) ? data.experience : []);
+  form.education = normalizeEducation(Array.isArray(data.education) ? data.education : []);
+}
+</script>

--- a/resume-builder/src/components/EducationGroup.vue
+++ b/resume-builder/src/components/EducationGroup.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="space-y-6">
+    <div
+      v-for="(item, index) in items"
+      :key="item.id"
+      class="rounded-lg border border-gray-200 p-4 shadow-sm dark:border-gray-700"
+    >
+      <div class="mb-4 flex items-center justify-between">
+        <h4 class="text-sm font-semibold text-gray-800 dark:text-gray-200">Education {{ index + 1 }}</h4>
+        <button
+          type="button"
+          class="text-sm text-red-600 hover:underline"
+          @click="remove(item.id)"
+        >
+          Remove
+        </button>
+      </div>
+      <div class="grid gap-4 md:grid-cols-2">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" :for="`school-${item.id}`">
+            School
+          </label>
+          <input
+            :id="`school-${item.id}`"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="item.school"
+            @input="updateField(item.id, 'school', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" :for="`degree-${item.id}`">
+            Degree
+          </label>
+          <input
+            :id="`degree-${item.id}`"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="item.degree"
+            @input="updateField(item.id, 'degree', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" :for="`years-${item.id}`">
+            Years
+          </label>
+          <input
+            :id="`years-${item.id}`"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="item.years"
+            @input="updateField(item.id, 'years', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+      </div>
+    </div>
+    <button
+      type="button"
+      class="rounded-md border border-dashed border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:border-blue-500 hover:text-blue-600 dark:border-gray-700 dark:text-gray-200 dark:hover:border-blue-400"
+      @click="add"
+    >
+      + Add Education
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { createEducationItem, type EducationItem } from '../lib/schema';
+
+const props = defineProps<{ items: EducationItem[] }>();
+const emit = defineEmits<{ (e: 'update', value: EducationItem[]): void }>();
+
+const items = computed(() => props.items);
+
+function updateField(id: string, field: keyof EducationItem, value: string) {
+  const next = items.value.map((item) =>
+    item.id === id ? { ...item, [field]: value } : item
+  );
+  emit('update', next);
+}
+
+function add() {
+  emit('update', [...items.value, createEducationItem()]);
+}
+
+function remove(id: string) {
+  if (items.value.length === 1) {
+    emit('update', [createEducationItem()]);
+    return;
+  }
+  emit('update', items.value.filter((item) => item.id !== id));
+}
+</script>

--- a/resume-builder/src/components/ExperienceGroup.vue
+++ b/resume-builder/src/components/ExperienceGroup.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="space-y-6">
+    <div
+      v-for="(item, index) in items"
+      :key="item.id"
+      class="rounded-lg border border-gray-200 p-4 shadow-sm dark:border-gray-700"
+    >
+      <div class="mb-4 flex items-center justify-between">
+        <h4 class="text-sm font-semibold text-gray-800 dark:text-gray-200">Experience {{ index + 1 }}</h4>
+        <button
+          type="button"
+          class="text-sm text-red-600 hover:underline"
+          @click="remove(item.id)"
+        >
+          Remove
+        </button>
+      </div>
+      <div class="grid gap-4 md:grid-cols-2">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" for="company-{{ item.id }}">
+            Company
+          </label>
+          <input
+            :id="`company-${item.id}`"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="item.company"
+            @input="updateField(item.id, 'company', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" for="role-{{ item.id }}">
+            Role
+          </label>
+          <input
+            :id="`role-${item.id}`"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="item.role"
+            @input="updateField(item.id, 'role', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" for="start-{{ item.id }}">
+            Start
+          </label>
+          <input
+            :id="`start-${item.id}`"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="item.start"
+            @input="updateField(item.id, 'start', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" for="end-{{ item.id }}">
+            End
+          </label>
+          <input
+            :id="`end-${item.id}`"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="item.end"
+            @input="updateField(item.id, 'end', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+      </div>
+      <div class="mt-4">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" :for="`description-${item.id}`">
+          Description / Bullets (one per line)
+        </label>
+        <textarea
+          :id="`description-${item.id}`"
+          rows="4"
+          class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+          :value="item.description"
+          @input="updateDescription(item.id, ($event.target as HTMLTextAreaElement).value)"
+        ></textarea>
+      </div>
+    </div>
+    <button
+      type="button"
+      class="rounded-md border border-dashed border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:border-blue-500 hover:text-blue-600 dark:border-gray-700 dark:text-gray-200 dark:hover:border-blue-400"
+      @click="add"
+    >
+      + Add Experience
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { createExperienceItem, type ExperienceItem, splitBullets } from '../lib/schema';
+
+const props = defineProps<{ items: ExperienceItem[] }>();
+const emit = defineEmits<{ (e: 'update', value: ExperienceItem[]): void }>();
+
+const items = computed(() => props.items);
+
+function updateField(id: string, field: keyof ExperienceItem, value: string | string[]) {
+  const next = items.value.map((item) =>
+    item.id === id ? { ...item, [field]: value } : item
+  );
+  emit('update', next);
+}
+
+function updateDescription(id: string, value: string) {
+  const bullets = splitBullets(value);
+  const next = items.value.map((item) =>
+    item.id === id
+      ? { ...item, description: value, descriptionBullets: bullets }
+      : item
+  );
+  emit('update', next);
+}
+
+function add() {
+  emit('update', [...items.value, createExperienceItem()]);
+}
+
+function remove(id: string) {
+  if (items.value.length === 1) {
+    emit('update', [createExperienceItem()]);
+    return;
+  }
+  emit('update', items.value.filter((item) => item.id !== id));
+}
+</script>

--- a/resume-builder/src/components/FormPanel.vue
+++ b/resume-builder/src/components/FormPanel.vue
@@ -1,0 +1,137 @@
+<template>
+  <form class="space-y-8" @submit.prevent>
+    <section class="space-y-4">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">Personal</h2>
+      <div class="grid gap-4 md:grid-cols-2">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" for="fullName">Full Name</label>
+          <input
+            id="fullName"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="form.personal.fullName"
+            @input="onPersonal('fullName', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" for="title">Title</label>
+          <input
+            id="title"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="form.personal.title"
+            @input="onPersonal('title', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" for="email">Email</label>
+          <input
+            id="email"
+            type="email"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="form.personal.email"
+            @input="onPersonal('email', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" for="phone">Phone</label>
+          <input
+            id="phone"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="form.personal.phone"
+            @input="onPersonal('phone', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" for="location">Location</label>
+          <input
+            id="location"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="form.personal.location"
+            @input="onPersonal('location', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300" for="website">Portfolio / LinkedIn</label>
+          <input
+            id="website"
+            type="text"
+            class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            :value="form.personal.website"
+            @input="onPersonal('website', ($event.target as HTMLInputElement).value)"
+          />
+        </div>
+      </div>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">Summary</h2>
+      <textarea
+        id="summary"
+        rows="4"
+        class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+        :value="form.summary"
+        @input="emit('update-summary', ($event.target as HTMLTextAreaElement).value)"
+      ></textarea>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">Experience</h2>
+      <ExperienceGroup :items="form.experience" @update="emit('update-experience', $event)" />
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">Education</h2>
+      <EducationGroup :items="form.education" @update="emit('update-education', $event)" />
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">Skills</h2>
+      <input
+        id="skills"
+        type="text"
+        placeholder="Comma-separated list"
+        class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+        :value="form.skills"
+        @input="emit('update-skills', ($event.target as HTMLInputElement).value)"
+      />
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">Target Job Description</h2>
+      <textarea
+        id="jobDescription"
+        rows="5"
+        placeholder="Optional"
+        class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+        :value="form.jobDescription"
+        @input="emit('update-job-description', ($event.target as HTMLTextAreaElement).value)"
+      ></textarea>
+    </section>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { toRef } from 'vue';
+import ExperienceGroup from './ExperienceGroup.vue';
+import EducationGroup from './EducationGroup.vue';
+import type { ResumeForm, PersonalInfo } from '../lib/schema';
+
+const props = defineProps<{ form: ResumeForm }>();
+const form = toRef(props, 'form');
+
+const emit = defineEmits<{
+  (e: 'update-personal', payload: { field: keyof PersonalInfo; value: string }): void;
+  (e: 'update-summary', value: string): void;
+  (e: 'update-experience', value: ResumeForm['experience']): void;
+  (e: 'update-education', value: ResumeForm['education']): void;
+  (e: 'update-skills', value: string): void;
+  (e: 'update-job-description', value: string): void;
+}>();
+
+function onPersonal(field: keyof PersonalInfo, value: string) {
+  emit('update-personal', { field, value });
+}
+</script>

--- a/resume-builder/src/components/PreviewPanel.vue
+++ b/resume-builder/src/components/PreviewPanel.vue
@@ -1,0 +1,29 @@
+<template>
+  <section class="h-full overflow-y-auto rounded-xl border border-gray-200 bg-white p-8 shadow-sm dark:border-gray-800 dark:bg-gray-950 print:border-0 print:shadow-none">
+    <component
+      :is="templateComponent"
+      :personal="form.personal"
+      :summary="form.summary"
+      :experience="form.experience"
+      :education="form.education"
+      :skills="skills"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import TemplateSimple from './TemplateSimple.vue';
+import TemplateModern from './TemplateModern.vue';
+import type { ResumeForm } from '../lib/schema';
+
+const props = defineProps<{
+  form: ResumeForm;
+  skills: string[];
+  template: 'simple' | 'modern';
+}>();
+
+const templateComponent = computed(() =>
+  props.template === 'modern' ? TemplateModern : TemplateSimple
+);
+</script>

--- a/resume-builder/src/components/TemplateModern.vue
+++ b/resume-builder/src/components/TemplateModern.vue
@@ -1,0 +1,83 @@
+<template>
+  <article class="print-page space-y-8">
+    <header class="space-y-3 border-b border-gray-200 pb-4 dark:border-gray-800">
+      <div>
+        <h1 class="text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">{{ personal.fullName || 'Your Name' }}</h1>
+        <p class="text-base font-medium text-gray-600 dark:text-gray-300">{{ personal.title || 'Professional Title' }}</p>
+      </div>
+      <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
+        <span v-if="personal.email">{{ personal.email }}</span>
+        <span v-if="personal.phone">{{ personal.phone }}</span>
+        <span v-if="personal.location">{{ personal.location }}</span>
+        <span v-if="personal.website">{{ personal.website }}</span>
+      </div>
+    </header>
+
+    <section v-if="summary" class="grid gap-2">
+      <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">Profile</h2>
+      <p class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-line">{{ summary }}</p>
+    </section>
+
+    <section v-if="experience.length" class="grid gap-4">
+      <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">Professional Experience</h2>
+      <div v-for="item in experience" :key="item.id" class="grid gap-2">
+        <div class="flex flex-wrap items-baseline justify-between gap-2">
+          <div>
+            <p class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ item.role || 'Role' }}</p>
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ item.company }}</p>
+          </div>
+          <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ formatRange(item.start, item.end) }}</p>
+        </div>
+        <ul v-if="bulletPoints(item).length" class="list-disc space-y-1 pl-5 text-sm text-gray-700 dark:text-gray-300">
+          <li v-for="(bullet, idx) in bulletPoints(item)" :key="idx">{{ bullet }}</li>
+        </ul>
+      </div>
+    </section>
+
+    <section v-if="education.length" class="grid gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">Education</h2>
+      <div v-for="item in education" :key="item.id" class="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <p class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ item.school }}</p>
+          <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ item.degree }}</p>
+        </div>
+        <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ item.years }}</p>
+      </div>
+    </section>
+
+    <section v-if="skills.length" class="grid gap-2">
+      <h2 class="text-sm font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">Core Skills</h2>
+      <div class="flex flex-wrap gap-2">
+        <span
+          v-for="skill in skills"
+          :key="skill"
+          class="rounded-md bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+        >
+          {{ skill }}
+        </span>
+      </div>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+import type { EducationItem, ExperienceItem, PersonalInfo } from '../lib/schema';
+import { splitBullets } from '../lib/schema';
+
+const props = defineProps<{
+  personal: PersonalInfo;
+  summary: string;
+  experience: ExperienceItem[];
+  education: EducationItem[];
+  skills: string[];
+}>();
+
+function formatRange(start: string, end: string) {
+  if (!start && !end) return '';
+  return [start, end || 'Present'].filter(Boolean).join(' • ');
+}
+
+function bulletPoints(item: ExperienceItem) {
+  return item.descriptionBullets.length ? item.descriptionBullets : splitBullets(item.description);
+}
+</script>

--- a/resume-builder/src/components/TemplateSimple.vue
+++ b/resume-builder/src/components/TemplateSimple.vue
@@ -1,0 +1,81 @@
+<template>
+  <article class="print-page space-y-8">
+    <header class="space-y-1">
+      <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100">{{ personal.fullName || 'Your Name' }}</h1>
+      <p class="text-lg font-medium text-gray-600 dark:text-gray-300">{{ personal.title || 'Professional Title' }}</p>
+      <p class="text-sm text-gray-500 dark:text-gray-400">
+        <span v-if="personal.email">{{ personal.email }}</span>
+        <span v-if="personal.phone"> • {{ personal.phone }}</span>
+        <span v-if="personal.location"> • {{ personal.location }}</span>
+        <span v-if="personal.website"> • {{ personal.website }}</span>
+      </p>
+    </header>
+
+    <section v-if="summary" class="space-y-2">
+      <h2 class="text-base font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-200">Summary</h2>
+      <p class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-line">{{ summary }}</p>
+    </section>
+
+    <section v-if="experience.length" class="space-y-4">
+      <h2 class="text-base font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-200">Experience</h2>
+      <div v-for="item in experience" :key="item.id" class="space-y-1">
+        <div class="flex flex-wrap items-baseline justify-between gap-2">
+          <div>
+            <p class="text-sm font-semibold text-gray-800 dark:text-gray-200">{{ item.role || 'Role' }}</p>
+            <p class="text-sm text-gray-600 dark:text-gray-400">{{ item.company }}</p>
+          </div>
+          <p class="text-sm text-gray-500 dark:text-gray-400">{{ formatRange(item.start, item.end) }}</p>
+        </div>
+        <ul v-if="bulletPoints(item).length" class="list-disc space-y-1 pl-5 text-sm text-gray-700 dark:text-gray-300">
+          <li v-for="(bullet, idx) in bulletPoints(item)" :key="idx">{{ bullet }}</li>
+        </ul>
+      </div>
+    </section>
+
+    <section v-if="education.length" class="space-y-3">
+      <h2 class="text-base font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-200">Education</h2>
+      <div v-for="item in education" :key="item.id" class="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <p class="text-sm font-semibold text-gray-800 dark:text-gray-200">{{ item.school }}</p>
+          <p class="text-sm text-gray-600 dark:text-gray-400">{{ item.degree }}</p>
+        </div>
+        <p class="text-sm text-gray-500 dark:text-gray-400">{{ item.years }}</p>
+      </div>
+    </section>
+
+    <section v-if="skills.length" class="space-y-2">
+      <h2 class="text-base font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-200">Skills</h2>
+      <div class="flex flex-wrap gap-2">
+        <span
+          v-for="skill in skills"
+          :key="skill"
+          class="rounded-full border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 dark:border-gray-700 dark:text-gray-200"
+        >
+          {{ skill }}
+        </span>
+      </div>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+import type { EducationItem, ExperienceItem, PersonalInfo } from '../lib/schema';
+import { splitBullets } from '../lib/schema';
+
+const props = defineProps<{
+  personal: PersonalInfo;
+  summary: string;
+  experience: ExperienceItem[];
+  education: EducationItem[];
+  skills: string[];
+}>();
+
+function formatRange(start: string, end: string) {
+  if (!start && !end) return '';
+  return [start, end || 'Present'].filter(Boolean).join(' – ');
+}
+
+function bulletPoints(item: ExperienceItem) {
+  return item.descriptionBullets.length ? item.descriptionBullets : splitBullets(item.description);
+}
+</script>

--- a/resume-builder/src/components/ThemeToggle.vue
+++ b/resume-builder/src/components/ThemeToggle.vue
@@ -1,0 +1,42 @@
+<template>
+  <button
+    type="button"
+    @click="toggle"
+    class="rounded-full border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+    :aria-pressed="isDark"
+  >
+    <span v-if="isDark">Light</span>
+    <span v-else>Dark</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+
+const isDark = ref(false);
+
+function applyTheme(dark: boolean) {
+  const root = document.documentElement;
+  if (dark) {
+    root.classList.add('dark');
+    localStorage.setItem('theme', 'dark');
+  } else {
+    root.classList.remove('dark');
+    localStorage.setItem('theme', 'light');
+  }
+  isDark.value = dark;
+}
+
+function toggle() {
+  applyTheme(!isDark.value);
+}
+
+onMounted(() => {
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    applyTheme(true);
+  } else {
+    applyTheme(false);
+  }
+});
+</script>

--- a/resume-builder/src/components/TopBar.vue
+++ b/resume-builder/src/components/TopBar.vue
@@ -1,0 +1,12 @@
+<template>
+  <header class="screen-only border-b border-gray-200 dark:border-gray-800 bg-white/70 dark:bg-gray-900/70 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <h1 class="text-lg font-semibold tracking-tight text-gray-900 dark:text-gray-100">Resume Builder</h1>
+      <ThemeToggle />
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+import ThemeToggle from './ThemeToggle.vue';
+</script>

--- a/resume-builder/src/lib/ai.ts
+++ b/resume-builder/src/lib/ai.ts
@@ -1,0 +1,49 @@
+import type { ResumeForm } from './schema';
+import { parseSkills } from './schema';
+
+export interface AiExperienceUpdate {
+  descriptionBullets: string[];
+}
+
+export interface AiResponse {
+  summary: string;
+  experience: AiExperienceUpdate[];
+  skills: string[];
+}
+
+export async function improveResume(form: ResumeForm): Promise<AiResponse> {
+  const payload = {
+    personal: form.personal,
+    summary: form.summary,
+    experience: form.experience.map((item) => ({
+      company: item.company,
+      role: item.role,
+      start: item.start,
+      end: item.end,
+      description: item.description
+    })),
+    education: form.education.map((item) => ({
+      school: item.school,
+      degree: item.degree,
+      years: item.years
+    })),
+    skills: parseSkills(form.skills),
+    jobDescription: form.jobDescription || undefined
+  };
+
+  const response = await fetch('/api/generate', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => ({ error: 'Unknown error' }));
+    throw new Error(errorBody.error || 'Failed to contact AI service.');
+  }
+
+  const data = (await response.json()) as AiResponse;
+  return data;
+}

--- a/resume-builder/src/lib/schema.ts
+++ b/resume-builder/src/lib/schema.ts
@@ -1,0 +1,101 @@
+export interface PersonalInfo {
+  fullName: string;
+  title: string;
+  email: string;
+  phone: string;
+  location: string;
+  website: string;
+}
+
+export interface ExperienceItem {
+  id: string;
+  company: string;
+  role: string;
+  start: string;
+  end: string;
+  description: string;
+  descriptionBullets: string[];
+}
+
+export interface EducationItem {
+  id: string;
+  school: string;
+  degree: string;
+  years: string;
+}
+
+export type TemplateType = 'simple' | 'modern';
+
+export interface ResumeForm {
+  personal: PersonalInfo;
+  summary: string;
+  experience: ExperienceItem[];
+  education: EducationItem[];
+  skills: string;
+  jobDescription: string;
+  template: TemplateType;
+}
+
+let uid = 0;
+
+function createId() {
+  uid += 1;
+  return `item-${Date.now()}-${uid}`;
+}
+
+export function createExperienceItem(): ExperienceItem {
+  return {
+    id: createId(),
+    company: '',
+    role: '',
+    start: '',
+    end: '',
+    description: '',
+    descriptionBullets: []
+  };
+}
+
+export function createEducationItem(): EducationItem {
+  return {
+    id: createId(),
+    school: '',
+    degree: '',
+    years: ''
+  };
+}
+
+export function createResumeForm(): ResumeForm {
+  return {
+    personal: {
+      fullName: '',
+      title: '',
+      email: '',
+      phone: '',
+      location: '',
+      website: ''
+    },
+    summary: '',
+    experience: [createExperienceItem()],
+    education: [createEducationItem()],
+    skills: '',
+    jobDescription: '',
+    template: 'simple'
+  };
+}
+
+export function parseSkills(input: string): string[] {
+  const unique = new Set(
+    input
+      .split(',')
+      .map((skill) => skill.trim())
+      .filter((skill) => skill.length > 0)
+  );
+  return Array.from(unique);
+}
+
+export function splitBullets(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}

--- a/resume-builder/src/lib/storage.ts
+++ b/resume-builder/src/lib/storage.ts
@@ -1,0 +1,51 @@
+import type { ResumeForm } from './schema';
+
+const STORAGE_KEY = 'resume-builder-data';
+
+export function saveResume(form: ResumeForm) {
+  const payload = JSON.stringify(form);
+  localStorage.setItem(STORAGE_KEY, payload);
+}
+
+export function loadResume(): ResumeForm | null {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ResumeForm;
+  } catch (error) {
+    console.error('Failed to parse stored resume', error);
+    return null;
+  }
+}
+
+export function clearResume() {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function downloadResume(form: ResumeForm) {
+  const blob = new Blob([JSON.stringify(form, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'resume.json';
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export function readResumeFile(file: File): Promise<ResumeForm> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(String(reader.result)) as ResumeForm;
+        resolve(data);
+      } catch (error) {
+        reject(new Error('Invalid resume JSON file.'));
+      }
+    };
+    reader.onerror = () => reject(new Error('Failed to read file.'));
+    reader.readAsText(file);
+  });
+}
+
+export { STORAGE_KEY };

--- a/resume-builder/src/main.ts
+++ b/resume-builder/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './styles.css';
+
+const app = createApp(App);
+app.mount('#app');

--- a/resume-builder/src/styles.css
+++ b/resume-builder/src/styles.css
@@ -1,0 +1,52 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+html,
+body,
+#app {
+  height: 100%;
+}
+
+body {
+  @apply bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 font-sans text-base leading-relaxed;
+}
+
+a {
+  @apply text-blue-600 dark:text-blue-400 underline-offset-4 hover:underline;
+}
+
+input,
+textarea,
+select,
+button {
+  @apply font-sans;
+}
+
+.print-only {
+  display: none;
+}
+
+@media print {
+  body {
+    background: white !important;
+  }
+
+  .screen-only {
+    display: none !important;
+  }
+
+  .print-only {
+    display: block !important;
+  }
+
+  .print-page {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+  }
+}

--- a/resume-builder/tailwind.config.js
+++ b/resume-builder/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['system-ui', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', 'sans-serif']
+      }
+    }
+  },
+  plugins: []
+};

--- a/resume-builder/tsconfig.app.json
+++ b/resume-builder/tsconfig.app.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "exclude": ["src/**/__tests__/*"]
+}

--- a/resume-builder/tsconfig.json
+++ b/resume-builder/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*", "env.d.ts"],
+  "references": [{ "path": "./tsconfig.app.json" }]
+}

--- a/resume-builder/tsconfig.node.json
+++ b/resume-builder/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/resume-builder/vite.config.ts
+++ b/resume-builder/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vue 3 + Tailwind resume builder with live preview, template toggle, and print-friendly styling
- add local persistence, JSON import/export, and OpenAI-powered improvements from the UI
- implement an Express API wrapper for OpenAI with validation, rate limiting, and project documentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e05a4ab2f4832eb46dcdb8850a876e